### PR TITLE
session.send_and_read doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You might need to log out for the extension to be listed.
 The following can be configured from the settings menu:
 + Select the date and time of your birth.
 + Select your birth sex and the country where you live.
-+ Click `Recalculate` to automatically fetch life expectancy from the WHO.
++ Click `Recalculate` to automatically fetch life expectancy from the WHO. (currently broken)
 + Select a display mode.
   + Count up from your birth, giving you your age.
   + Count down from your life expectancy, giving you the number of years until your expected death.


### PR DESCRIPTION
Heya, I tried to fix this myself for a long time, but I couldn't figure it out. Any country codes, including USA, do not work. I have boiled down the problem to line 35 of prefs.js, or `        const data = session.send_and_read(request, null)`. From my testing, this method does not exist. I tried to list all of the methods that *do* exist but came up empty. Soup.Session only has the function `new`. From testing, I've found that commit https://github.com/keyoted/thanatophobia/commit/9c710d6906b8e9513e14486f07604f1b83680951 is the cause; reverting it fixes it all right up. I didn't want to revert it since it was probably done for a reason, but I wanted to report the issue.